### PR TITLE
module.ceylon: Update java-vertx module dependencies to use maven repo…

### DIFF
--- a/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/auth/common/module.ceylon
+++ b/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/auth/common/module.ceylon
@@ -3,5 +3,5 @@ module io.vertx.ceylon.auth.common "${project.version}" {
   native("jvm") import java.base "7";
   shared import ceylon.json "1.3.0";
   shared import io.vertx.ceylon.core "${project.version}";
-  shared import "io.vertx.vertx-auth-common" "${project.version}";
+  shared import maven:"io.vertx:vertx-auth-common" "${project.version}";
 }

--- a/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/auth/jdbc/module.ceylon
+++ b/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/auth/jdbc/module.ceylon
@@ -4,5 +4,5 @@ module io.vertx.ceylon.auth.jdbc "${project.version}" {
   shared import ceylon.json "1.3.0";
   shared import io.vertx.ceylon.auth.common "${project.version}";
   shared import io.vertx.ceylon.jdbc "${project.version}";
-  shared import "io.vertx.vertx-auth-jdbc" "${project.version}";
+  shared import maven:"io.vertx:vertx-auth-jdbc" "${project.version}";
 }

--- a/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/auth/jwt/module.ceylon
+++ b/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/auth/jwt/module.ceylon
@@ -3,5 +3,5 @@ module io.vertx.ceylon.auth.jwt "${project.version}" {
   native("jvm") import java.base "7";
   shared import ceylon.json "1.3.0";
   shared import io.vertx.ceylon.auth.common "${project.version}";
-  shared import "io.vertx.vertx-auth-jwt" "${project.version}";
+  shared import maven:"io.vertx:vertx-auth-jwt" "${project.version}";
 }

--- a/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/auth/oauth2/module.ceylon
+++ b/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/auth/oauth2/module.ceylon
@@ -3,5 +3,5 @@ module io.vertx.ceylon.auth.oauth2 "${project.version}" {
   native("jvm") import java.base "7";
   shared import ceylon.json "1.3.0";
   shared import io.vertx.ceylon.auth.common "${project.version}";
-  shared import "io.vertx.vertx-auth-oauth2" "${project.version}";
+  shared import maven:"io.vertx:vertx-auth-oauth2" "${project.version}";
 }

--- a/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/auth/shiro/module.ceylon
+++ b/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/auth/shiro/module.ceylon
@@ -3,5 +3,5 @@ module io.vertx.ceylon.auth.shiro "${project.version}" {
   native("jvm") import java.base "7";
   shared import ceylon.json "1.3.0";
   shared import io.vertx.ceylon.auth.common "${project.version}";
-  shared import "io.vertx.vertx-auth-shiro" "${project.version}";
+  shared import maven:"io.vertx:vertx-auth-shiro" "${project.version}";
 }

--- a/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/jdbc/module.ceylon
+++ b/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/jdbc/module.ceylon
@@ -3,5 +3,5 @@ module io.vertx.ceylon.jdbc "${project.version}" {
   native("jvm") import java.base "7";
   shared import ceylon.json "1.3.0";
   shared import io.vertx.ceylon.sql "${project.version}";
-  shared import "io.vertx.vertx-jdbc-client" "${project.version}";
+  shared import maven:"io.vertx:vertx-jdbc-client" "${project.version}";
 }

--- a/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/sql/module.ceylon
+++ b/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/sql/module.ceylon
@@ -3,5 +3,5 @@ module io.vertx.ceylon.sql "${project.version}" {
   native("jvm") import java.base "7";
   shared import ceylon.json "1.3.0";
   shared import io.vertx.ceylon.core "${project.version}";
-  shared import "io.vertx.vertx-sql-common" "${project.version}";
+  shared import maven:"io.vertx:vertx-sql-common" "${project.version}";
 }

--- a/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/web/module.ceylon
+++ b/vertx-lang-ceylon-stack/src/main/ceylon/io/vertx/ceylon/web/module.ceylon
@@ -3,13 +3,13 @@ module io.vertx.ceylon.web "${project.version}" {
   native("jvm") import java.base "7";
   shared import ceylon.json "1.3.0";
   shared import io.vertx.ceylon.core "${project.version}";
-  shared import "io.vertx.vertx-web" "${project.version}";
+  shared import maven:"io.vertx:vertx-web" "${project.version}";
   shared optional import io.vertx.ceylon.auth.jwt "${project.version}";
   shared optional import io.vertx.ceylon.auth.oauth2 "${project.version}";
-  shared optional import "io.vertx.vertx-web-templ-handlebars" "${project.version}";
-  shared optional import "io.vertx.vertx-web-templ-thymeleaf" "${project.version}";
-  shared optional import "io.vertx.vertx-web-templ-jade" "${project.version}";
-  shared optional import "io.vertx.vertx-web-templ-mvel" "${project.version}";
-  shared optional import "io.vertx.vertx-web-templ-pebble" "${project.version}";
-  shared optional import "io.vertx.vertx-web-templ-freemarker" "${project.version}";
+  shared optional import maven:"io.vertx:vertx-web-templ-handlebars" "${project.version}";
+  shared optional import maven:"io.vertx:vertx-web-templ-thymeleaf" "${project.version}";
+  shared optional import maven:"io.vertx:vertx-web-templ-jade" "${project.version}";
+  shared optional import maven:"io.vertx:vertx-web-templ-mvel" "${project.version}";
+  shared optional import maven:"io.vertx:vertx-web-templ-pebble" "${project.version}";
+  shared optional import maven:"io.vertx:vertx-web-templ-freemarker" "${project.version}";
 }

--- a/vertx-lang-ceylon/src/main/ceylon/io/vertx/ceylon/core/module.ceylon
+++ b/vertx-lang-ceylon/src/main/ceylon/io/vertx/ceylon/core/module.ceylon
@@ -3,5 +3,5 @@ module io.vertx.ceylon.core "${project.version}" {
   native("jvm") import java.base "7";
   shared import ceylon.json "1.3.0";
   shared import io.vertx.lang.ceylon "${project.version}";
-  shared import "io.vertx.vertx-core" "${project.version}"; // io.vertx.ceylon.core
+  shared import maven:"io.vertx:vertx-core" "${project.version}"; // io.vertx.ceylon.core
 }

--- a/vertx-lang-ceylon/src/main/ceylon/io/vertx/lang/ceylon/module.ceylon
+++ b/vertx-lang-ceylon/src/main/ceylon/io/vertx/lang/ceylon/module.ceylon
@@ -1,7 +1,7 @@
 module io.vertx.lang.ceylon "${project.version}" {
   shared import "java.base" "7";
   shared import "ceylon.json" "1.3.0";
-  shared import "io.vertx.vertx-core" "${project.version}";
+  shared import maven:"io.vertx:vertx-core" "${project.version}";
   shared import "com.redhat.ceylon.compiler.java" "1.3.0";
   shared import "com.redhat.ceylon.tool.provider" "1.3.0";
 }

--- a/vertx-lang-ceylon/src/test/ceylon/io/vertx/ceylon/testmodel/module.ceylon
+++ b/vertx-lang-ceylon/src/test/ceylon/io/vertx/ceylon/testmodel/module.ceylon
@@ -3,5 +3,5 @@ module io.vertx.ceylon.testmodel "${project.version}" {
   native("jvm") import java.base "7";
   shared import ceylon.json "1.3.0";
   shared import io.vertx.lang.ceylon "${project.version}";
-  shared import "io.vertx.vertx-codegen-tck" "${project.version}"; // io.vertx.ceylon.codegen.testmodel
+  shared import maven:"io.vertx:vertx-codegen-tck" "${project.version}"; // io.vertx.ceylon.codegen.testmodel
 }


### PR DESCRIPTION
…instead of CMR

- no need to upload all java deps to CMR (Ceylon Herd)
- source jars available for end-users through maven repos

I understand that this probably affects the development environment somewhat but since the dependencies are in fact maven modules, just running "mvn install" on the vert-x3 projects should suffice..