### PR TITLE
Eliminate excessive Byte type checking

### DIFF
--- a/vertx-lang-ceylon/src/main/ceylon/io/vertx/lang/ceylon/ToJava.java
+++ b/vertx-lang-ceylon/src/main/ceylon/io/vertx/lang/ceylon/ToJava.java
@@ -16,8 +16,6 @@ public class ToJava {
       converter = Character;
     } else if (o instanceof ceylon.language.Integer) {
       converter = Long;
-    } else if (o instanceof ceylon.language.Byte) {
-      converter = Byte;
     } else if (o instanceof ceylon.language.Float) {
       converter = Double;
     } else if (o instanceof ceylon.json.Object) {


### PR DESCRIPTION
`instaceof ceylon.language.Byte` is verified 2 times which looks like excessive.