### PR TITLE
add Instant to DataObject tests

### DIFF
--- a/vertx-lang-ceylon/src/main/resources/vertx-ceylon/template/ceylon-dataobject.templ
+++ b/vertx-lang-ceylon/src/main/resources/vertx-ceylon/template/ceylon-dataobject.templ
@@ -36,6 +36,8 @@
       decl = getTypeAlias(type);
     } else if (kind == CLASS_STRING) {
       decl = 'String';
+    } else if (kind == CLASS_INSTANT) {
+      decl = 'String';
     } else if (isInteger(type)) {
       decl = 'Integer';
     } else if (isFloat(type)) {
@@ -83,6 +85,8 @@
     if (prop.kind.value) {
       if (type.kind == CLASS_STRING) {
         return expr + '.getStringOrNull("' + prop.name + '")';
+      } else if (type.kind == CLASS_INSTANT) {
+        return expr + '.getStringOrNull("' + prop.name + '")';
       } else if (isInteger(type)) {
         return expr + '.getIntegerOrNull("' + prop.name + '")';
       } else if (isBoolean(type)) {
@@ -105,6 +109,8 @@
     } else if (prop.kind.list) {
       if (type.kind == CLASS_STRING) {
         return expr + '.getArrayOrNull("' + prop.name + '")?.strings';
+      } else if (type.kind == CLASS_INSTANT) {
+        return expr + '.getArrayOrNull("' + prop.name + '")?.strings';
       } else if (isInteger(type)) {
         return expr + '.getArrayOrNull("' + prop.name + '")?.integers';
       } else if (isFloat(type)) {
@@ -126,6 +132,8 @@
       }
     } else if (prop.kind.map) {
       if (type.kind == CLASS_STRING) {
+        return 'if (exists tmp = ' + expr + '.getObjectOrNull("' + prop.name + '")) then HashMap { for(key->val in tmp) if (is String val) key->val } else null';
+      } else if (type.kind == CLASS_INSTANT) {
         return 'if (exists tmp = ' + expr + '.getObjectOrNull("' + prop.name + '")) then HashMap { for(key->val in tmp) if (is String val) key->val } else null';
       } else if (isInteger(type)) {
         return 'if (exists tmp = ' + expr + '.getObjectOrNull("' + prop.name + '")) then HashMap { for(key->val in tmp) if (is Integer val) key->val } else null';

--- a/vertx-lang-ceylon/src/main/resources/vertx-ceylon/template/ceylon-dataobject.templ
+++ b/vertx-lang-ceylon/src/main/resources/vertx-ceylon/template/ceylon-dataobject.templ
@@ -36,8 +36,6 @@
       decl = getTypeAlias(type);
     } else if (kind == CLASS_STRING) {
       decl = 'String';
-    } else if (kind == CLASS_INSTANT) {
-      decl = 'String';
     } else if (isInteger(type)) {
       decl = 'Integer';
     } else if (isFloat(type)) {
@@ -65,6 +63,8 @@
       return '{' + decl + '*}';
     } else if (prop.kind.map) {
       return 'Map<String, ' + decl + '>';
+    } else if (kind == CLASS_OTHER && type.name.equals('java.time.Instant')) {
+      reutrn 'String';
     } else {
       return 'Nothing /* ' + prop +  ' */';
     }
@@ -85,8 +85,6 @@
     if (prop.kind.value) {
       if (type.kind == CLASS_STRING) {
         return expr + '.getStringOrNull("' + prop.name + '")';
-      } else if (type.kind == CLASS_INSTANT) {
-        return expr + '.getStringOrNull("' + prop.name + '")';
       } else if (isInteger(type)) {
         return expr + '.getIntegerOrNull("' + prop.name + '")';
       } else if (isBoolean(type)) {
@@ -105,11 +103,11 @@
         } else {
           return expr + '.getStringOrNull("' + prop.name + '")';
         }
+      } else if (type.kind == CLASS_OTHER && type.name.equals('java.time.Instant')) {
+        return expr + '.getStringOrNull("' + prop.name + '")';
       }
     } else if (prop.kind.list) {
       if (type.kind == CLASS_STRING) {
-        return expr + '.getArrayOrNull("' + prop.name + '")?.strings';
-      } else if (type.kind == CLASS_INSTANT) {
         return expr + '.getArrayOrNull("' + prop.name + '")?.strings';
       } else if (isInteger(type)) {
         return expr + '.getArrayOrNull("' + prop.name + '")?.integers';
@@ -129,11 +127,11 @@
         } else {
           return expr + '.getArrayOrNull("' + prop.name + '")?.strings';
         }
+      } else if (type.kind == CLASS_OTHER) {
+        return expr + '.getArrayOrNull("' + prop.name + '")?.strings';
       }
     } else if (prop.kind.map) {
       if (type.kind == CLASS_STRING) {
-        return 'if (exists tmp = ' + expr + '.getObjectOrNull("' + prop.name + '")) then HashMap { for(key->val in tmp) if (is String val) key->val } else null';
-      } else if (type.kind == CLASS_INSTANT) {
         return 'if (exists tmp = ' + expr + '.getObjectOrNull("' + prop.name + '")) then HashMap { for(key->val in tmp) if (is String val) key->val } else null';
       } else if (isInteger(type)) {
         return 'if (exists tmp = ' + expr + '.getObjectOrNull("' + prop.name + '")) then HashMap { for(key->val in tmp) if (is Integer val) key->val } else null';
@@ -147,12 +145,14 @@
         return 'if (exists tmp = ' + expr + '.getObjectOrNull("' + prop.name + '")) then HashMap { for(key->val in tmp) if (is JsonArray val) key->val } else null';
       } else if (type.kind == CLASS_DATA_OBJECT) {
         return 'if (exists tmp = ' + expr + '.getObjectOrNull("' + prop.name + '")) then HashMap { for(key->val in tmp) if (is JsonObject val) key->' + CASE_CAMEL.to(CASE_LOWER_CAMEL, type.simpleName) + '_.fromJson(val) } else null';
-      } if (type.kind == CLASS_ENUM) {
+      } else if (type.kind == CLASS_ENUM) {
         if (type.gen) {
           return 'if (exists tmp = ' + expr + '.getObjectOrNull("' + prop.name + '")) then HashMap { for(key->val in tmp) if (is String val) key->' + CASE_CAMEL.to(CASE_LOWER_CAMEL, type.simpleName) + '_.fromString(val) } else null';
         } else {
           return 'if (exists tmp = ' + expr + '.getObjectOrNull("' + prop.name + '")) then HashMap { for(key->val in tmp) if (is String val) key->val } else null';
         }
+      } else if (type.kind == CLASS_OTHER) {
+        return 'if (exists tmp = ' + expr + '.getObjectOrNull("' + prop.name + '")) then HashMap { for(key->val in tmp) if (is String val) key->val } else null';
       }
     }
     return 'null /* ' + type + ' not handled */';

--- a/vertx-lang-ceylon/src/test/ceylon/io/vertx/ceylon/testmodel/DataObjectWithListAdders.ceylon
+++ b/vertx-lang-ceylon/src/test/ceylon/io/vertx/ceylon/testmodel/DataObjectWithListAdders.ceylon
@@ -33,6 +33,7 @@ shared class DataObjectWithListAdders(
   shared {String*}? enumValues = null,
   shared {Float*}? floatValues = null,
   shared {TestGenEnum*}? genEnumValues = null,
+  shared {String*}? instantValues = null,
   shared {Integer*}? integerValues = null,
   shared {JsonArray*}? jsonArrayValues = null,
   shared {JsonObject*}? jsonObjectValues = null,
@@ -58,6 +59,9 @@ shared class DataObjectWithListAdders(
     }
     if (exists genEnumValues) {
       json.put("genEnumValues", JsonArray(genEnumValues.map(testGenEnum_.toString)));
+    }
+    if (exists instantValues) {
+      json.put("instantValues", JsonArray(instantValues));
     }
     if (exists integerValues) {
       json.put("integerValues", JsonArray(integerValues));
@@ -90,6 +94,7 @@ shared object dataObjectWithListAdders {
     {String*}? enumValues = json.getArrayOrNull("enumValues")?.strings;
     {Float*}? floatValues = json.getArrayOrNull("floatValues")?.floats;
     {TestGenEnum*}? genEnumValues = json.getArrayOrNull("genEnumValues")?.strings?.map(testGenEnum_.fromString);
+    {String*}? instantValues = json.getArrayOrNull("instantValues")?.strings;
     {Integer*}? integerValues = json.getArrayOrNull("integerValues")?.integers;
     {JsonArray*}? jsonArrayValues = json.getArrayOrNull("jsonArrayValues")?.arrays;
     {JsonObject*}? jsonObjectValues = json.getArrayOrNull("jsonObjectValues")?.objects;
@@ -103,6 +108,7 @@ shared object dataObjectWithListAdders {
       enumValues = enumValues;
       floatValues = floatValues;
       genEnumValues = genEnumValues;
+      instantValues = instantValues;
       integerValues = integerValues;
       jsonArrayValues = jsonArrayValues;
       jsonObjectValues = jsonObjectValues;

--- a/vertx-lang-ceylon/src/test/ceylon/io/vertx/ceylon/testmodel/DataObjectWithLists.ceylon
+++ b/vertx-lang-ceylon/src/test/ceylon/io/vertx/ceylon/testmodel/DataObjectWithLists.ceylon
@@ -33,6 +33,7 @@ shared class DataObjectWithLists(
   shared {String*}? enumValues = null,
   shared {Float*}? floatValues = null,
   shared {TestGenEnum*}? genEnumValues = null,
+  shared {String*}? instantValues = null,
   shared {Integer*}? integerValues = null,
   shared {JsonArray*}? jsonArrayValues = null,
   shared {JsonObject*}? jsonObjectValues = null,
@@ -58,6 +59,9 @@ shared class DataObjectWithLists(
     }
     if (exists genEnumValues) {
       json.put("genEnumValues", JsonArray(genEnumValues.map(testGenEnum_.toString)));
+    }
+    if (exists instantValues) {
+      json.put("instantValues", JsonArray(instantValues));
     }
     if (exists integerValues) {
       json.put("integerValues", JsonArray(integerValues));
@@ -90,6 +94,7 @@ shared object dataObjectWithLists {
     {String*}? enumValues = json.getArrayOrNull("enumValues")?.strings;
     {Float*}? floatValues = json.getArrayOrNull("floatValues")?.floats;
     {TestGenEnum*}? genEnumValues = json.getArrayOrNull("genEnumValues")?.strings?.map(testGenEnum_.fromString);
+    {String*}? instantValues = json.getArrayOrNull("instantValues")?.strings;
     {Integer*}? integerValues = json.getArrayOrNull("integerValues")?.integers;
     {JsonArray*}? jsonArrayValues = json.getArrayOrNull("jsonArrayValues")?.arrays;
     {JsonObject*}? jsonObjectValues = json.getArrayOrNull("jsonObjectValues")?.objects;
@@ -103,6 +108,7 @@ shared object dataObjectWithLists {
       enumValues = enumValues;
       floatValues = floatValues;
       genEnumValues = genEnumValues;
+      instantValues = instantValues;
       integerValues = integerValues;
       jsonArrayValues = jsonArrayValues;
       jsonObjectValues = jsonObjectValues;

--- a/vertx-lang-ceylon/src/test/ceylon/io/vertx/ceylon/testmodel/DataObjectWithMapAdders.ceylon
+++ b/vertx-lang-ceylon/src/test/ceylon/io/vertx/ceylon/testmodel/DataObjectWithMapAdders.ceylon
@@ -33,6 +33,7 @@ shared class DataObjectWithMapAdders(
   shared Map<String, String>? enumValues = null,
   shared Map<String, Float>? floatValues = null,
   shared Map<String, TestGenEnum>? genEnumValues = null,
+  shared Map<String, String>? instantValues = null,
   shared Map<String, Integer>? integerValues = null,
   shared Map<String, JsonArray>? jsonArrayValues = null,
   shared Map<String, JsonObject>? jsonObjectValues = null,
@@ -58,6 +59,9 @@ shared class DataObjectWithMapAdders(
     }
     if (exists genEnumValues) {
       json.put("genEnumValues", JsonObject{for(k->v in genEnumValues) k->testGenEnum_.toString(v)});
+    }
+    if (exists instantValues) {
+      json.put("instantValues", JsonObject(instantValues));
     }
     if (exists integerValues) {
       json.put("integerValues", JsonObject(integerValues));
@@ -90,6 +94,7 @@ shared object dataObjectWithMapAdders {
     Map<String, String>? enumValues = if (exists tmp = json.getObjectOrNull("enumValues")) then HashMap { for(key->val in tmp) if (is String val) key->val } else null;
     Map<String, Float>? floatValues = if (exists tmp = json.getObjectOrNull("floatValues")) then HashMap { for(key->val in tmp) if (is Float val) key->val } else null;
     Map<String, TestGenEnum>? genEnumValues = if (exists tmp = json.getObjectOrNull("genEnumValues")) then HashMap { for(key->val in tmp) if (is String val) key->testGenEnum_.fromString(val) } else null;
+    Map<String, String>? instantValues = if (exists tmp = json.getObjectOrNull("instantValues")) then HashMap { for(key->val in tmp) if (is String val) key->val } else null;
     Map<String, Integer>? integerValues = if (exists tmp = json.getObjectOrNull("integerValues")) then HashMap { for(key->val in tmp) if (is Integer val) key->val } else null;
     Map<String, JsonArray>? jsonArrayValues = if (exists tmp = json.getObjectOrNull("jsonArrayValues")) then HashMap { for(key->val in tmp) if (is JsonArray val) key->val } else null;
     Map<String, JsonObject>? jsonObjectValues = if (exists tmp = json.getObjectOrNull("jsonObjectValues")) then HashMap { for(key->val in tmp) if (is JsonObject val) key->val } else null;
@@ -103,6 +108,7 @@ shared object dataObjectWithMapAdders {
       enumValues = enumValues;
       floatValues = floatValues;
       genEnumValues = genEnumValues;
+      instantValues = instantValues;
       integerValues = integerValues;
       jsonArrayValues = jsonArrayValues;
       jsonObjectValues = jsonObjectValues;

--- a/vertx-lang-ceylon/src/test/ceylon/io/vertx/ceylon/testmodel/DataObjectWithMaps.ceylon
+++ b/vertx-lang-ceylon/src/test/ceylon/io/vertx/ceylon/testmodel/DataObjectWithMaps.ceylon
@@ -33,6 +33,7 @@ shared class DataObjectWithMaps(
   shared Map<String, String>? enumValues = null,
   shared Map<String, Float>? floatValues = null,
   shared Map<String, TestGenEnum>? genEnumValues = null,
+  shared Map<String, String>? instantValues = null,
   shared Map<String, Integer>? integerValues = null,
   shared Map<String, JsonArray>? jsonArrayValues = null,
   shared Map<String, JsonObject>? jsonObjectValues = null,
@@ -58,6 +59,9 @@ shared class DataObjectWithMaps(
     }
     if (exists genEnumValues) {
       json.put("genEnumValues", JsonObject{for(k->v in genEnumValues) k->testGenEnum_.toString(v)});
+    }
+    if (exists instantValues) {
+      json.put("instantValues", JsonObject(instantValues));
     }
     if (exists integerValues) {
       json.put("integerValues", JsonObject(integerValues));
@@ -90,6 +94,7 @@ shared object dataObjectWithMaps {
     Map<String, String>? enumValues = if (exists tmp = json.getObjectOrNull("enumValues")) then HashMap { for(key->val in tmp) if (is String val) key->val } else null;
     Map<String, Float>? floatValues = if (exists tmp = json.getObjectOrNull("floatValues")) then HashMap { for(key->val in tmp) if (is Float val) key->val } else null;
     Map<String, TestGenEnum>? genEnumValues = if (exists tmp = json.getObjectOrNull("genEnumValues")) then HashMap { for(key->val in tmp) if (is String val) key->testGenEnum_.fromString(val) } else null;
+    Map<String, String>? instantValues = if (exists tmp = json.getObjectOrNull("instantValues")) then HashMap { for(key->val in tmp) if (is String val) key->val } else null;
     Map<String, Integer>? integerValues = if (exists tmp = json.getObjectOrNull("integerValues")) then HashMap { for(key->val in tmp) if (is Integer val) key->val } else null;
     Map<String, JsonArray>? jsonArrayValues = if (exists tmp = json.getObjectOrNull("jsonArrayValues")) then HashMap { for(key->val in tmp) if (is JsonArray val) key->val } else null;
     Map<String, JsonObject>? jsonObjectValues = if (exists tmp = json.getObjectOrNull("jsonObjectValues")) then HashMap { for(key->val in tmp) if (is JsonObject val) key->val } else null;
@@ -103,6 +108,7 @@ shared object dataObjectWithMaps {
       enumValues = enumValues;
       floatValues = floatValues;
       genEnumValues = genEnumValues;
+      instantValues = instantValues;
       integerValues = integerValues;
       jsonArrayValues = jsonArrayValues;
       jsonObjectValues = jsonObjectValues;

--- a/vertx-lang-ceylon/src/test/ceylon/io/vertx/ceylon/testmodel/DataObjectWithValues.ceylon
+++ b/vertx-lang-ceylon/src/test/ceylon/io/vertx/ceylon/testmodel/DataObjectWithValues.ceylon
@@ -39,6 +39,7 @@ shared class DataObjectWithValues(
   shared String? enumValue = null,
   shared Float? floatValue = null,
   shared TestGenEnum? genEnumValue = null,
+  shared String? instantValue = null,
   shared Integer? intValue = null,
   shared JsonArray? jsonArrayValue = null,
   shared JsonObject? jsonObjectValue = null,
@@ -83,6 +84,9 @@ shared class DataObjectWithValues(
     if (exists genEnumValue) {
       json.put("genEnumValue", testGenEnum_.toString(genEnumValue));
     }
+    if (exists instantValue) {
+      json.put("instantValue", instantValue);
+    }
     if (exists intValue) {
       json.put("intValue", intValue);
     }
@@ -120,6 +124,7 @@ shared object dataObjectWithValues {
     String? enumValue = json.getStringOrNull("enumValue");
     Float? floatValue = json.getFloatOrNull("floatValue");
     TestGenEnum? genEnumValue = if (exists tmp = json.getStringOrNull("genEnumValue")) then testGenEnum_.fromString(tmp) else null;
+    String? instantValue = json.getStringOrNull("instantValue");
     Integer? intValue = json.getIntegerOrNull("intValue");
     JsonArray? jsonArrayValue = json.getArrayOrNull("jsonArrayValue");
     JsonObject? jsonObjectValue = json.getObjectOrNull("jsonObjectValue");
@@ -139,6 +144,7 @@ shared object dataObjectWithValues {
       enumValue = enumValue;
       floatValue = floatValue;
       genEnumValue = genEnumValue;
+      instantValue = instantValue;
       intValue = intValue;
       jsonArrayValue = jsonArrayValue;
       jsonObjectValue = jsonObjectValue;

--- a/vertx-lang-ceylon/src/test/ceylon/io/vertx/tests/dataObjectTCKTests.ceylon
+++ b/vertx-lang-ceylon/src/test/ceylon/io/vertx/tests/dataObjectTCKTests.ceylon
@@ -32,6 +32,7 @@ shared test void testReadDataObjectWithValues() {
   assertEquals(2.2, dataObject.boxedFloatValue);
   assertEquals(2.22, dataObject.boxedDoubleValue);
   assertEquals("wibble", dataObject.stringValue);
+  assertEquals("1984-05-27T00:05:00Z", dataObject.instantValue);
   assertEquals(JsonObject{"foo"->"eek","bar"->"wibble"}, dataObject.jsonObjectValue);
   assertEquals(JsonArray{"eek","wibble"}, dataObject.jsonArrayValue);
   assertEquals("TIM", dataObject.enumValue);
@@ -56,6 +57,7 @@ shared test void testWriteDataObjectWithValues() {
     boxedFloatValue = 2.2;
     boxedDoubleValue = 2.22;
     stringValue = "wibble";
+    instantValue = "1984-05-27T00:05:00Z";
     jsonObjectValue = JsonObject{"foo"->"eek","bar"->"wibble"};
     jsonArrayValue = JsonArray{"eek","wibble"};
     enumValue = "TIM";
@@ -81,6 +83,8 @@ shared test void testReadDataObjectWithLists() {
   assertEquals(ArrayList{1.11,2.22,3.33}, ArrayList{*doubleValues});
   assert(exists stringValues = dataObject.stringValues);
   assertEquals(ArrayList{"stringValues1","stringValues2","stringValues3"}, ArrayList{*stringValues});
+  assert(exists instantValues = dataObject.instantValues);
+  assertEquals(ArrayList{"1984-05-27T00:05:00Z", "2018-07-05T08:23:21Z"}, ArrayList{*instantValues});
   assert(exists jsonObjectValues = dataObject.jsonObjectValues);
   assertEquals(ArrayList{JsonObject{"foo"->"eek"},JsonObject{"foo"->"wibble"}}, ArrayList{*jsonObjectValues});
   assert(exists jsonArrayValues = dataObject.jsonArrayValues);
@@ -106,6 +110,7 @@ shared test void testWriteDataObjectWithLists() {
     jsonObjectValues = {JsonObject{"foo"->"eek"},JsonObject{"foo"->"wibble"}};
     jsonArrayValues = {JsonArray{"foo"},JsonArray{"bar"}};
     stringValues = { "stringValues1", "stringValues2", "stringValues3" };
+    instantValues = { "1984-05-27T00:05:00Z", "2018-07-05T08:23:21Z" };
     dataObjectValues = { TestDataObject { foo="1"; bar=1; wibble=1.1; }, TestDataObject { foo="2"; bar=2; wibble=2.2; } };
     enumValues = { "TIM", "JULIEN" };
     genEnumValues = { bob, laura };
@@ -120,6 +125,7 @@ shared test void testReadDataObjectWithMaps() {
   assertEquals(HashMap{"1"->123456,"2"->654321}, dataObject.integerValues);
   assertEquals(HashMap{"1"->123456789,"2"->987654321}, dataObject.longValues);
   assertEquals(HashMap{"1"->"stringValues1","2"->"stringValues2"}, dataObject.stringValues);
+  assertEquals(HashMap{"1"->"1984-05-27T00:05:00Z","2"->"2018-07-05T08:23:21Z"}, dataObject.instantValues);
   assertEquals(HashMap{"1"->JsonObject{"foo"->"eek"},"2"->JsonObject{"foo"->"wibble"}}, dataObject.jsonObjectValues);
   assertEquals(HashMap{"1"->JsonArray{"foo"},"2"->JsonArray{"bar"}}, dataObject.jsonArrayValues);
   assertEquals("1", dataObject.dataObjectValues?.get("1")?.foo);
@@ -141,6 +147,7 @@ shared test void testWriteDataObjectWithMaps() {
     floatValues = HashMap { "1"->1.1, "2"->2.2 };
     doubleValues = HashMap { "1"->1.11, "2"->2.22 };
     stringValues = HashMap { "1"->"stringValues1", "2"->"stringValues2" };
+    instantValues = HashMap { "1"->"1984-05-27T00:05:00Z", "2"->"2018-07-05T08:23:21Z" };
     jsonObjectValues = HashMap { "1"->JsonObject{"foo"->"eek"}, "2"->JsonObject{"foo"->"wibble"} };
     jsonArrayValues = HashMap { "1"->JsonArray{"foo"}, "2"->JsonArray{"bar"} };
     dataObjectValues = HashMap { "1"-> TestDataObject { foo="1"; bar=1; wibble=1.1; },"2" -> TestDataObject { foo="2"; bar=2; wibble=2.2; } };


### PR DESCRIPTION
[This PR](https://github.com/vert-x3/vertx-codegen/pull/195) adds support for `Instant` in `DataObject`s. This one here adds `Instant` to the ceylon tests.